### PR TITLE
Fix Wavesurfer compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LoopMe</title>
     <link rel="stylesheet" href="style.css">
-    <!-- Wavesurfer.js from CDN -->
-    <script src="https://unpkg.com/wavesurfer.js@7"></script>
-    <script src="https://unpkg.com/wavesurfer.js@7/dist/plugins/regions.min.js"></script>
+    <!-- Wavesurfer.js v6 for compatibility with current script -->
+    <script src="https://unpkg.com/wavesurfer.js@6"></script>
+    <script src="https://unpkg.com/wavesurfer.js@6/dist/plugin/wavesurfer.regions.min.js"></script>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
## Summary
- load Wavesurfer.js v6 instead of v7 so `main.js` functions work

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6878685ae658833395aad84a7bd6e7eb