### PR TITLE
Fix regions plugin reference in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ let wavesurfer = WaveSurfer.create({
   waveColor: '#a0a0a0',
   progressColor: '#333',
   plugins: [
-    WaveSurfer.Regions.create({})
+    WaveSurfer.regions.create({})
   ]
 });
 


### PR DESCRIPTION
## Summary
- correct Wavesurfer regions plugin name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687869f49f3c8333bc54393657521182