### PR TITLE
Fix audio worklet paths and initialization for Electron

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,11 @@
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 
+// Permite ejecutar Electron como root en entornos limitados
+if (process.platform === 'linux' && process.getuid && process.getuid() === 0) {
+  app.commandLine.appendSwitch('no-sandbox');
+}
+
 function createWindow() {
   const win = new BrowserWindow({
     width: 800,

--- a/renderer.js
+++ b/renderer.js
@@ -44,9 +44,12 @@ async function ensureWorklet(context) {
     alert("AudioWorklet no soportado en este navegador.");
     return false;
   }
+
   if (!workletLoaded) {
+    // Ruta absoluta al procesador para evitar problemas al usar file:// en Electron
+    const moduleUrl = new URL('./soundtouch-processor.js', import.meta.url);
     try {
-      await context.audioWorklet.addModule("soundtouch-processor.js");
+      await context.audioWorklet.addModule(moduleUrl.href);
       workletLoaded = true;
     } catch (e) {
       console.error(e);
@@ -54,6 +57,7 @@ async function ensureWorklet(context) {
       return false;
     }
   }
+
   return true;
 }
 

--- a/soundtouch-processor.js
+++ b/soundtouch-processor.js
@@ -70,8 +70,13 @@ class SoundTouchProcessor extends AudioWorkletProcessor {
     }
     const extracted = this.filter.extract(this.samples, frames);
     for (let i = 0; i < frames; i++) {
-      left[i] = this.samples[i * 2];
-      right[i] = this.samples[i * 2 + 1];
+      if (i < extracted) {
+        left[i] = this.samples[i * 2];
+        right[i] = this.samples[i * 2 + 1];
+      } else {
+        left[i] = 0;
+        right[i] = 0;
+      }
     }
     if (extracted === 0) {
       this.filter.onEnd();


### PR DESCRIPTION
## Summary
- allow running Electron without sandbox when executed as root
- load `soundtouch-processor.js` via absolute URL in renderer
- clear leftover audio frames in `SoundTouchProcessor`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687921bc5d608333a9f50284b602c563