### PR TITLE
Fix worklet support warning

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -41,7 +41,7 @@ function resumeContext() {
 
 async function ensureWorklet(context) {
   if (!context || !context.audioWorklet) {
-    alert("AudioWorklet no soportado en este navegador.");
+    console.warn("AudioWorklet no soportado en este navegador.");
     return false;
   }
 


### PR DESCRIPTION
## Summary
- log a warning to console instead of alerting when AudioWorklet is missing

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687923a6f94083339c95613ee99cc703