### PR TITLE
Add loop offset compensation option

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,11 @@
                     <button id="zoom-out">-</button>
                 </div>
             </div>
+            <!-- Ajuste temporal del reinicio del loop -->
+            <div class="control-group">
+                <label for="loop-offset">Compensación de loop (ms)</label>
+                <input type="number" id="loop-offset" step="0.1" value="0">
+            </div>
         </div>
     </div>
     <script type="module" src="soundtouch.js"></script>

--- a/renderer.js
+++ b/renderer.js
@@ -20,6 +20,8 @@ let currentSourcePosition = 0;
 const PROCESS_LATENCY_SAMPLES = 4096;
 // Nivel de zoom en px por segundo aplicado a la onda
 let zoomLevel = 100;
+// Valor de compensación de loop en milisegundos
+let loopOffsetMs = 0;
 
 // Lista de tiempos de ataque detectados en el audio
 let transientPoints = [];
@@ -174,6 +176,13 @@ pitchControl.addEventListener('input', () => {
 const zoomControl = document.getElementById('zoom');
 const zoomInBtn = document.getElementById('zoom-in');
 const zoomOutBtn = document.getElementById('zoom-out');
+// Input para la compensación de loop en ms (se puede eliminar junto con las
+// referencias si se quiere dejar un valor fijo)
+const loopOffsetInput = document.getElementById('loop-offset');
+
+loopOffsetInput.addEventListener('input', () => {
+  loopOffsetMs = parseFloat(loopOffsetInput.value) || 0;
+});
 
 // Cambia el nivel de zoom aplicando .zoom(pxPerSec)
 function applyZoom(value) {
@@ -267,14 +276,16 @@ function startSync() {
   const baseLatency = context.baseLatency || 0;
   const latencyTime = PROCESS_LATENCY_SAMPLES / sampleRate + baseLatency;
   const duration = wavesurfer.getDuration();
+  const offsetTime = loopOffsetMs / 1000; // compensación en segundos
 
   loopHandler = async (time) => {
     let current = filterNode ? currentSourcePosition / sampleRate : time;
 
     if (looping && currentRegion) {
       const { start, end } = currentRegion;
-      // Reiniciar justo antes de terminar el loop teniendo en cuenta la latencia
-      if (current >= end - latencyTime) {
+      // Reiniciar cerca del final del loop sumando la compensación
+      // (ajustar o eliminar este bloque si se desea fijar el valor)
+      if (current >= end + offsetTime - latencyTime) {
         await createSoundTouchFilter(start);
         wavesurfer.seekTo(start / duration); // sincroniza la vista
         current = start;

--- a/style.css
+++ b/style.css
@@ -58,3 +58,9 @@ input[type=range] {
   width: 100px;
   margin-top: 0.5rem;
 }
+
+/* Tamaño del cuadro de compensación de loop */
+input#loop-offset {
+  width: 80px;
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add input field for loop compensation in ms
- wire new control in `renderer.js` and apply offset during loop restart
- style text field for better alignment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687926d97a20833391ec6f0b2e3c74fb