### PR TITLE
Fix loop re-sync by flushing worklet buffer

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -282,13 +282,17 @@ function startSync() {
     let current = filterNode ? currentSourcePosition / sampleRate : time;
     if (looping && currentRegion) {
       const { start, end } = currentRegion;
-      if (!pendingSeek && current >= end + compensacionLoop) {
-        pendingSeek = true;
-        await createSoundTouchFilter(start);
-        wavesurfer.seekTo(start / duration);
-        console.log(`Loop jump at ${current.toFixed(3)}s using compensacionLoop=${compensacionLoop}s`);
-        pendingSeek = false;
-      }
+        if (!pendingSeek && current >= end + compensacionLoop) {
+          pendingSeek = true;
+          await createSoundTouchFilter(start);
+          wavesurfer.seekTo(start / duration);
+          wavesurfer.pause(); // flush
+          setTimeout(() => {
+            wavesurfer.play();
+            pendingSeek = false;
+          }, 10);
+          console.log(`Loop jump at ${current.toFixed(3)}s using compensacionLoop=${compensacionLoop}s`);
+        }
     }
 
     wavesurfer.drawer.progress(current / duration);


### PR DESCRIPTION
## Summary
- flush AudioWorklet buffer during loop jump

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6879383d9e788333ab1cfad2c6c7a182